### PR TITLE
feat: Overhaul chat and Pokedex UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -285,7 +285,7 @@
                         <div class="pokemon-card" style="width: 800px; max-height: 70vh; display: flex; flex-direction: column; background: rgba(33, 37, 41, 0.9); backdrop-filter: blur(10px); border: 1px solid var(--gray-700); border-radius: var(--radius-lg); box-shadow: var(--shadow-xl);">
                             <header class="d-flex align-items-center justify-content-between p-4" style="border-bottom: 1px solid var(--gray-700); cursor: grab;" data-drag-handle="true">
                                 <h2 style="font-size: var(--text-lg); font-weight: 700; color: var(--white);">Pokédex</h2>
-                                <button id="pokedex-close-button" class="pokemon-btn" style="padding: var(--space-2); background: transparent; color: white;">
+                                <button id="pokedex-close-button" class="pokemon-btn" style="padding: var(--space-2); background: transparent; color: white; border: none;">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
                                 </button>
                             </header>

--- a/public/js/new_chat.js
+++ b/public/js/new_chat.js
@@ -178,4 +178,18 @@ class NewChatManager {
     }
 }
 
-window.newChatManager = new NewChatManager();
+document.addEventListener('DOMContentLoaded', () => {
+    window.newChatManager = new NewChatManager();
+    // The chat manager needs the socket instance.
+    // We can get it from the game manager when it's initialized.
+    const originalGameInit = window.gameManager?.initialize;
+    if (originalGameInit) {
+        window.gameManager.initialize = function(...args) {
+            return originalGameInit.apply(this, args).then(() => {
+                if (window.newChatManager && this.socket) {
+                    window.newChatManager.initialize(this.socket);
+                }
+            });
+        };
+    }
+});


### PR DESCRIPTION
This commit implements two major UI updates as requested, ensuring they appear only on the main game screen.

1.  **Functional Pokédex:**
    *   Added the HTML structure for a new Pokédex window and a bottom action bar to the main game screen container in `index.html`.
    *   The Pokédex button on the action bar now toggles the visibility of the Pokédex window.
    *   The Pokédex window is hidden by default using CSS.
    *   A close button on the Pokédex window also hides it.

2.  **Overhauled Chat Window:**
    *   Replaced the old chat UI with a new, modern design from the `new_design/` folder within the main game screen.
    *   The new chat window is draggable via its header.
    *   The chat logic has been updated in a new `new_chat.js` file to support the new UI, including sending and receiving messages.

**Implementation Notes:**
*   To avoid issues with merge conflicts in the original `main.js` and `chat.js` files, the new JavaScript logic was placed in separate files (`pokedex.js`, `new_chat.js`, `draggable.js`).
*   The `index.html` file was updated to load these new scripts, ensuring a clean implementation without touching the conflicted files.
*   This version corrects a previous error where the new UI elements were visible on the loading screen. They are now correctly scoped to the game screen only.

**Testing:**
An attempt was made to run the Playwright tests (`npm run test:playwright`), but it failed due to missing system dependencies in the environment. This prevented a full UI test from being completed. The changes are submitted with the assumption that they will be tested in a correctly configured environment.